### PR TITLE
Updated run to use lite-server

### DIFF
--- a/bs-config.json
+++ b/bs-config.json
@@ -1,0 +1,4 @@
+{
+    "port": 8000,
+    "server": {"baseDir": "./public"}
+}

--- a/package.json
+++ b/package.json
@@ -6,14 +6,14 @@
   "scripts": {
     "build": "webpack",
     "watch": "webpack --progress --watch",
-    "start": "http-server -p 8000",
+    "start": "lite-server",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "Bill Barnes",
   "license": "MIT",
   "devDependencies": {
     "awesome-typescript-loader": "^3.1.2",
-    "http-server": "^0.9.0",
+    "lite-server": "^2.3.0",
     "source-map-loader": "^0.2.1",
     "typescript": "^2.2.2",
     "webpack": "^2.3.2"


### PR DESCRIPTION
Updated package.json to call [lite-server](https://github.com/johnpapa/lite-server), and added a config (bsconfig.json) to keep the same hosting structure for the sample already in existence. The advantage to using lite-server is it will automatically refresh the browser whenever changes are made.